### PR TITLE
Add custom anchors to NSURLProtectionSpace's serverTrust property

### DIFF
--- a/MOLAuthenticatingURLSession.podspec
+++ b/MOLAuthenticatingURLSession.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'MOLAuthenticatingURLSession'
-  s.version      = '2.0'
+  s.version      = '2.1'
   s.platform     = :osx
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
   s.homepage     = 'https://github.com/google/macops-molauthenticatingurlsession'


### PR DESCRIPTION
-  Fix for issue: https://github.com/google/macops-MOLAuthenticatingURLSession/issues/6
-  Surfaced through: https://github.com/google/santa/issues/88
