### PR TITLE
Update Podspec, someone has become case-sensitive.

### DIFF
--- a/MOLAuthenticatingURLSession.podspec
+++ b/MOLAuthenticatingURLSession.podspec
@@ -3,10 +3,10 @@ Pod::Spec.new do |s|
   s.version      = '2.2'
   s.platform     = :osx
   s.license      = { :type => 'Apache 2.0', :file => 'LICENSE' }
-  s.homepage     = 'https://github.com/google/macops-molauthenticatingurlsession'
+  s.homepage     = 'https://github.com/google/macops-MOLAuthenticatingURLSession'
   s.authors      = { 'Google Macops' => 'macops-external@google.com' }
   s.summary      = 'An NSURLSession wrapper that handles certificate validation nicely'
-  s.source       = { :git => 'https://github.com/google/macops-molauthenticatingurlsession.git',
+  s.source       = { :git => 'https://github.com/google/macops-MOLAuthenticatingURLSession.git',
                      :tag => "v#{s.version}" }
   s.source_files = 'Source/*.{h,m}'
   s.framework    = 'Security'


### PR DESCRIPTION
Cloning the URL in Cocoapods no longer seems to work properly