### PR TITLE
Retain identityRef retrieved from file

### DIFF
--- a/Source/MOLAuthenticatingURLSession.m
+++ b/Source/MOLAuthenticatingURLSession.m
@@ -403,8 +403,11 @@
     [self log:@"Client Trust: Couldn't load client certificate %@: %d", self.clientCertFile, err];
     return nil;
   }
+  
+  CFDictionaryRef firstDict = [identities firstObject];
+  SecIdentityRef firstRef = (__bridge SecIdentityRef)firstDict[(__bridge id)kSecImportItemIdentity];
 
-  return (__bridge SecIdentityRef)[identities firstObject][(__bridge id)kSecImportItemIdentity];
+  return (firstRef != NULL) ? CFRetain(firstRef) : NULL;
 }
 
 - (void)log:(NSString *)format, ... {


### PR DESCRIPTION
Currently the identity has a chance to be released before it's added to an NSURLCredential.